### PR TITLE
Fix the queryTip() call to send the chainSyncMsgDone at the end to te…

### DIFF
--- a/shelley/socket.go
+++ b/shelley/socket.go
@@ -1,6 +1,7 @@
 package shelley
 
 import (
+	"io"
 	"net"
 	"time"
 
@@ -72,7 +73,7 @@ func (s *UnixSocket) Write(payload []byte) (*multiplex.Container, error) {
 	////////////////////////////////////////////////////////////
 	header := make([]byte, 8)
 	readCount, err := s.connection.Read(header)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		log.WithError(err).Error("Error reading packet header of size 8 bytes")
 		return nil, err
 	}


### PR DESCRIPTION
Fix the queryTip() call to send the chainSyncMsgDone at the end to terminate the connection, otherwise the cardano-node would log the following:

[String "ErrorPolicyUnhandledApplicationException (MuxError MuxBearerClosed \"<socket: 53> closed when reading data, waiting on next header True\")",String "ErrorPolicyTrace",String "LocalAddress {getFilePath = \"\"}"]